### PR TITLE
Frontend Envars

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Open a second terminal window. You should now have two terminal windows open: on
 ```bash
 cd frontend
 npm install
-npm run samples-setup-env
+npm run setup-env
 ```
 
 To launch the frontend of your Squid application, run the following command from the `front` directory:

--- a/README.md
+++ b/README.md
@@ -2,24 +2,77 @@
 
 Welcome to Squid Cloud! This project contains a to-do application in which you will add Squid functionality. The steps to complete the project are displayed in the frontend, so the first step is to get the frontend up and running locally.
 
-1. Open a terminal window, and then navigate to the frontend:
+## Prerequisites
+
+For this project you will need:
+
+- NodeJS v18 or later.
+- A Squid Cloud account and a Squid application. To sign up for Squid, go to [Squid Cloud Console](https://console.squid.cloud). Once signed up, you can create an application.
+- The Squid Cloud CLI (`npm i @squidcloud/cli`).
+
+## Environment configuration
+
+### Setting up your `.env` file
+
+After cloning this project, go to the [Squid Cloud Console](https://console.squid.cloud), create an application (if haven't done so already) and click the **Create .env file** button under **Backend project**. This provides you with the command to create the `.env` file required for this template to work and run.
+
+Change to the backend directory, and install the required dependencies:
 
 ```bash
-cd todo/frontend
-```
-
-2. Install the required dependencies:
-
-```bash
+cd backend
 npm install
 ```
 
-3. Start the frontend by running the following command:
+Run the initialization command you copied from the console. The command has the following format:
+
+```bash
+squid init-env \
+ --appId YOUR_APP_ID \
+ --apiKey YOUR_API_KEY \
+ --environmentId YOUR_ENVIRONMENT_ID \
+ --squidDeveloperId YOUR_SQUID_DEVELOPER_ID \
+ --region YOUR_REGION
+```
+
+## Running the application
+
+### Starting the local backend server
+
+To launch the local backend server of your Squid application, run the following command from the `backend` directory:
+
+```bash
+squid start
+```
+
+You'll see output similar to the following, indicating that your server is up and running:
+
+```bash
+> nodemon --watch ./src --exec ts-node -r tsconfig-paths/register src/main.ts
+[Nest] 68047  - 03/15/2024, 7:55:23 PM     LOG [NestApplication] Nest application successfully started +1ms
+```
+
+### Launching the frontend server
+
+Open a second terminal window. You should now have two terminal windows open: one running the local backend server, and one in which you will run the frontend. Initialize the frontend server by running the following commands:
+
+```bash
+cd frontend
+npm install
+npm run samples-setup-env
+```
+
+To launch the frontend of your Squid application, run the following command from the `front` directory:
 
 ```bash
 npm run dev
 ```
 
-4. Click the URL in the terminal logs to open the app (likely http://localhost:5173/). The page displays your todo application and the accompanying tutorial.
+Verify that Vite server has started, providing URLs to access your app:
 
-Follow the steps in the application to begin building!
+```bash
+  VITE v5.1.6  ready in 149 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
+  ➜  press h + enter to show help
+```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@squidcloud/react": "^1.0.48",
-        "@squidcloud/samples": "^1.0.5",
+        "@squidcloud/samples": "^1.0.6",
         "@squidcloud/ui": "^1.0.5",
         "dayjs": "^1.11.10",
         "react": "^18.2.0",
@@ -1326,11 +1326,11 @@
       }
     },
     "node_modules/@squidcloud/samples": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@squidcloud/samples/-/samples-1.0.5.tgz",
-      "integrity": "sha512-B66BQYBHKvWZN7/Zq9gRhyD2pokcat/yKChW8Bc25WwP1FAmLXpgLg5PSTJ+wGeyE3ad7hjGsClgBEt42HEQRQ==",
-      "dependencies": {
-        "highlight.js": "^11.9.0"
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@squidcloud/samples/-/samples-1.0.6.tgz",
+      "integrity": "sha512-q8vJsoZ5jjfS/cskPD1pwyJW4Wbb5CMJMSQwfDfYAAVCZz7qIP5619yvNkEMiVRmXnm5J1Gnds2yAew6CaR4Hg==",
+      "bin": {
+        "samples-setup-env": "scripts/setup-env.js"
       }
     },
     "node_modules/@squidcloud/ui": {
@@ -2719,14 +2719,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/highlight.js": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
-      "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/hoist-non-react-statics": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "samples-setup-env": "samples-setup-env --prefix VITE_",
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
@@ -11,7 +12,7 @@
   },
   "dependencies": {
     "@squidcloud/react": "^1.0.48",
-    "@squidcloud/samples": "^1.0.5",
+    "@squidcloud/samples": "^1.0.6",
     "@squidcloud/ui": "^1.0.5",
     "dayjs": "^1.11.10",
     "react": "^18.2.0",

--- a/frontend/public/tutorial.md
+++ b/frontend/public/tutorial.md
@@ -1,54 +1,6 @@
-## Getting Started
+## Creating a To-do
 
 Welcome to your first Squid project! Through a few simple steps, you will add functionality to a full-stack to-do application and learn about some of the features of Squid.
-
-1. In the [Squid Cloud Console](https://console.squid.cloud) create a new app called `todo`.
-
-2. To initialize Squid in a client app, you must provide some details about your Squid application. In the `frontend` directory, create a new file called `.env.local`, and populate it with your `appId`, `region` and `squidDeveloperId`. You can find these values in the application overview page of the [Squid Cloud Console](https://console.squid.cloud):
-
-```env
-VITE_SQUID_APP_ID=YOUR_APP_ID # Update the App ID
-VITE_SQUID_REGION=us-east-1.aws
-VITE_SQUID_ENVIRONMENT_ID=dev
-VITE_SQUID_DEVELOPER_ID=YOUR_SQUID_DEVELOPER_ID # Update the developer ID
-```
-
-3. In the [Squid Cloud Console](https://console.squid.cloud), scroll to the **Backend project** section and click **Create .env file**.
-
-4. Open a new terminal window. You should now have two terminal windows open: one running the frontend of this app as instructed in the README, and another window that will run the backend. Copy the command to install the Squid CLI, and then run it in the terminal:
-
-```bash
-npm install -g @squidcloud/cli
-```
-
-The Squid CLI lets you run your Squid projects locally during development and testing, and then deploy your backend when ready.
-
-5. Navigate to the `backend` directory:
-
-```bash
-cd backend
-```
-
-6. Copy the command to create the `.env` file that's shown in the **Backend project** section of the Squid Cloud Console, and then run it in the `backend` directory. The command has the following format:
-
-```bash
-squid init-env \
---appId YOUR_APP_ID \
---apiKey YOUR_API_KEY \
---environmentId dev \
---squidDeveloperId YOUR_SQUID_DEVELOPER_KEY \
---region us-east-1.aws
-```
-
-7. In the `backend` directory, run the following command:
-
-```bash
-squid start
-```
-
-Your Squid backend is now running locally for development and testing! Click **Next** to continue to the next step where you add your first Squid functionality to this app.
-
-## Creating a To-do
 
 Right now, the **Add Todo** button displays a modal for adding a new to-do to the list, but saving a to-do does not produce any effect. Let's add some code that writes new to-do tasks to Squid's [built-in database](https://docs.squid.cloud/docs/integrations/database/built-in) and also listens for updates to the to-dos.
 

--- a/frontend/public/tutorial.md
+++ b/frontend/public/tutorial.md
@@ -4,19 +4,13 @@ Welcome to your first Squid project! Through a few simple steps, you will add fu
 
 1. In the [Squid Cloud Console](https://console.squid.cloud) create a new app called `todo`.
 
-2. To initialize Squid in a client app, you must provide some details about your Squid application. In the `main.tsx` file of the frontend, update the options passed to `SquidContextProvider` with your `appId` and `squidDeveloperId`. You can find these values in the application overview page of the [Squid Cloud Console](https://console.squid.cloud):
+2. To initialize Squid in a client app, you must provide some details about your Squid application. In the `frontend` directory, create a new file called `.env.local`, and populate it with your `appId`, `region` and `squidDeveloperId`. You can find these values in the application overview page of the [Squid Cloud Console](https://console.squid.cloud):
 
-```typescript
-...
-  <SquidContextProvider
-    options={{
-      appId: 'YOUR_APP_ID', // Update the App ID
-      region: 'us-east-1.aws',
-      environmentId: 'dev',
-      squidDeveloperId: 'YOUR_SQUID_DEVELOPER_ID', // Update the developer ID
-    }}
-  >
-...
+```env
+VITE_SQUID_APP_ID=YOUR_APP_ID # Update the App ID
+VITE_SQUID_REGION=us-east-1.aws
+VITE_SQUID_ENVIRONMENT_ID=dev
+VITE_SQUID_DEVELOPER_ID=YOUR_SQUID_DEVELOPER_ID # Update the developer ID
 ```
 
 3. In the [Squid Cloud Console](https://console.squid.cloud), scroll to the **Backend project** section and click **Create .env file**.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,10 +7,10 @@ import { Tutorial } from "@squidcloud/samples/react";
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <SquidContextProvider
     options={{
-      appId: 'YOUR_APP_ID',
-      region: 'us-east-1.aws',
-      environmentId: 'dev',
-      squidDeveloperId: 'YOUR_SQUID_DEVELOPER_ID',
+      appId: import.meta.env.VITE_SQUID_APP_ID,
+      region: import.meta.env.VITE_SQUID_REGION,
+      environmentId: import.meta.env.VITE_SQUID_ENVIRONMENT_ID,
+      squidDeveloperId: import.meta.env.VITE_SQUID_DEVELOPER_ID,
     }}
   >
     <Tutorial title="todo" />


### PR DESCRIPTION
Updates the README and tutorial steps to reflect the new process of creating envars in the frontend using the `samples-setup-env` create.

We no longer instruction users to create an app and initialize the env inside the tutorial itself, because this will be done either through 1) the README or 2) the onboarding flow.